### PR TITLE
Update pixie-diag.sh

### DIFF
--- a/pixie-diag.sh
+++ b/pixie-diag.sh
@@ -26,8 +26,8 @@ echo ""
 # Check for px
 if ! [ -x "$(command -v px)" ]; then
   echo 'Info: px (Pixie CLI) is not installed. Agent status report will be unavailable.' >&2
-  echo 'You can install the Pixie CLI by running:' >&2
-  echo 'bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"' >&2
+  echo 'You can install the Pixie CLI by running:'
+  echo 'bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"'
   else
   echo "Get agent status from Pixie"
   px run px/agent_status

--- a/pixie-diag.sh
+++ b/pixie-diag.sh
@@ -25,7 +25,9 @@ echo ""
 
 # Check for px
 if ! [ -x "$(command -v px)" ]; then
-  echo 'Error: px is not installed.' >&2
+  echo 'Info: px (Pixie CLI) is not installed. Agent status report will be unavailable.' >&2
+  echo 'You can install the Pixie CLI by running:' >&2
+  echo 'bash -c "$(curl -fsSL https://withpixie.ai/install.sh)"' >&2
   else
   echo "Get agent status from Pixie"
   px run px/agent_status


### PR DESCRIPTION
Improvements to message displayed when 'px' Pixie CLI is not present. 
* Prints "Info" instead of "Error", with the justification that this is not a blocker for the rest of the script functions, and does not significantly reduce the utility of the total output for troubleshooting (the 'px' output is useful, but the majority of the diagnostics seem to come from k8s API output). We don't want the user to panic if they don't have 'px' - most NR integration users will not have it.
* Clarifies 'px' as Pixie CLI. Some users interpret the existing message as meaning Pixie itself is not present.
* Include command to get the CLI installed, in case they are using the New Relic integration (if they go hunting for this information, they will find the Pixie CLI installation page, which contains information which is inapplicable for this use case, which is confusing).